### PR TITLE
Update file paths to tests and filpaths in tests

### DIFF
--- a/src/test/iteration-0.test.js
+++ b/src/test/iteration-0.test.js
@@ -1,5 +1,5 @@
 import DistrictRepository from '../../src/helper.js';
-import kinderData from '../../data/kindergartners_in_full_day_program.js';
+import kinderData from '../data/kindergartners_in_full_day_program.js';
 
 describe('DistrictRepository iteration 0', () =>  {
   const district = new DistrictRepository(kinderData);

--- a/src/test/iteration-1-part1.test.js
+++ b/src/test/iteration-1-part1.test.js
@@ -1,5 +1,5 @@
 import DistrictRepository from '../../src/helper.js';
-import kinderData from '../../data/kindergartners_in_full_day_program.js';
+import kinderData from '../data/kindergartners_in_full_day_program.js';
 
 describe('DistrictRepository iteration 1 - part 1', () =>  {
   const district = new DistrictRepository(kinderData);

--- a/src/test/iteration-1-part2.test.js
+++ b/src/test/iteration-1-part2.test.js
@@ -1,5 +1,5 @@
 import DistrictRepository from '../../src/helper.js';
-import kinderData from '../../data/kindergartners_in_full_day_program.js';
+import kinderData from '../data/kindergartners_in_full_day_program.js';
 
 describe('DistrictRepository iteration 1 - part 2', () =>  {
   const district = new DistrictRepository(kinderData);

--- a/src/test/iteration-4.test.js
+++ b/src/test/iteration-4.test.js
@@ -1,5 +1,5 @@
 import DistrictRepository from '../../src/helper.js';
-import kinderData from '../../data/kindergartners_in_full_day_program.js';
+import kinderData from '../data/kindergartners_in_full_day_program.js';
 
 describe('DistrictRepository iteration 0', () =>  {
   const district = new DistrictRepository(kinderData);


### PR DESCRIPTION
To get this to work on my machine, I had to: 
- move test/unit/ directory into the src/ directory
- remove the unit/ sub directory and move test files directly into test/ directory
- update the file paths of the KinderData import in each test file to go back only one directory

Let's be sure to test this on your machine to make sure the tests are still running. 